### PR TITLE
Fixes keyword passed when enumerable

### DIFF
--- a/lib/chic/presents.rb
+++ b/lib/chic/presents.rb
@@ -90,7 +90,7 @@ module Chic
 
     def present(object, with: nil)
       if object.is_a?(Enumerable)
-        object.map { |o| present(o, with) }
+        object.map { |o| present(o, with: with) }
       elsif with.present?
         with.new(object, context)
       elsif object.nil?

--- a/lib/chic/version.rb
+++ b/lib/chic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Chic
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
Just ran into this when doing:
```
class FooPresenter < Chic::Presenter
  presents bars: BarPresenter # i.e., Foo has_many :bars
end
```